### PR TITLE
Fix oneOf usage for connection parameters

### DIFF
--- a/dist/1.5.x/openapi.yaml
+++ b/dist/1.5.x/openapi.yaml
@@ -1635,11 +1635,9 @@ components:
         wol-wait-time:
           type: string
     ConnectionParameters:
-      type: array
-      items:
-        oneOf:
-          - $ref: '#/components/schemas/ConnectionParametersVNC'
-          - $ref: '#/components/schemas/ConnectionParametersRDP'
+      oneOf:
+        - $ref: '#/components/schemas/ConnectionParametersVNC'
+        - $ref: '#/components/schemas/ConnectionParametersRDP'
     ConnectionRequest:
       type: object
       properties:

--- a/openapi/components/schemas/ConnectionParameters.yaml
+++ b/openapi/components/schemas/ConnectionParameters.yaml
@@ -1,5 +1,3 @@
-type: array
-items:
-  oneOf:
-    - $ref: ConnectionParametersVNC.yaml
-    - $ref: ConnectionParametersRDP.yaml
+oneOf:
+  - $ref: ConnectionParametersVNC.yaml
+  - $ref: ConnectionParametersRDP.yaml


### PR DESCRIPTION
Was defined as an array, instead of plain objects.