### PR TITLE
Make parent of connection group required

### DIFF
--- a/dist/1.5.x/openapi.yaml
+++ b/dist/1.5.x/openapi.yaml
@@ -1696,6 +1696,7 @@ components:
       required:
         - identifier
         - name
+        - parentIdentifier
         - type
         - attributes
       example:

--- a/openapi/components/schemas/ConnectionGroup.yaml
+++ b/openapi/components/schemas/ConnectionGroup.yaml
@@ -36,6 +36,7 @@ properties:
 required:
   - identifier
   - name
+  - parentIdentifier
   - type
   - attributes
 example:


### PR DESCRIPTION
In every case, the parent of a connection group has to be set.